### PR TITLE
Fix unpinned certificate name

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,7 @@ echo "Running certbot to generate initial signed cert"
 echo "Using server ${LETSENCRYPT_SERVER_URL}"
 
 certbot certonly --server ${LETSENCRYPT_SERVER_URL} --standalone \
+        --cert-name ${DOMAIN_FIRST} \
         --preferred-challenges http-01 $DOMAIN_ARGS \
         --email $LETSENCRYPT_EMAIL --agree-tos \
         --noninteractive --no-redirect \


### PR DESCRIPTION
When updating certificate SANs list, Certbot will create a new certificate
instead of updating the existing one. See [here](https://community.letsencrypt.org/t/prevent-0001-xxxx-certificate-suffixes/66802).
Using ${DOMAIN_FIRST} so that certificate files get generated at
/etc/letsencrypt/live/$DOMAIN_FIRST where the script search for them.